### PR TITLE
Hide image if imageFile is undefined

### DIFF
--- a/_includes/projects.html
+++ b/_includes/projects.html
@@ -50,7 +50,10 @@
                         <div class="row">
 
                             <div class="col-md-3 col-s-12">
-                                <img src="images_packages/{{ project.imageFile }}" style="max-width: 100%; max-height: 100px;" /></div>
+                                {% if project.imageFile %}
+                                <img src="images_packages/{{ project.imageFile }}" style="max-width: 100%; max-height: 100px;" />
+                                {% endif %}
+                            </div>
                             <div class="col-md-9">
                                 <a href="{{ project.mainURL }}">
                                     <div class="projectname name">{{ project.name }}</div>


### PR DESCRIPTION
Resolves #54 

No image will be shown if the `imageFile` property does not exist in the `_data/projects.json` entry.