### PR TITLE
Add compatibility for main branch named main

### DIFF
--- a/_data/projects.json
+++ b/_data/projects.json
@@ -4,8 +4,8 @@
     "category": "Reconstruction",
     "shortDescription": "A high-level, easy-to-deploy non-uniform Fast Fourier Transform in PyTorch.",
     "imageFile": "torchkbnufft.png",
-    "mainURL": "https://torchkbnufft.readthedocs.io/en/stable/",
-    "repoURL": "https://github.com/mmuckley/torchkbnufft/",
+    "mainURL": "https://torchkbnufft.readthedocs.io/en/stable",
+    "repoURL": "https://github.com/mmuckley/torchkbnufft",
     "principalDevelopers": "Matthew J. Muckley, Ruben Stern, Tullie Murrell and Florian Knoll",
     "longDescription": "torchkbnufft implements a non-uniform Fast Fourier Transform with Kaiser-Bessel gridding in PyTorch. The implementation is completely in Python, facilitating flexible deployment in readable code with no compilation. NUFFT functions are each wrapped as a torch.autograd.Function, allowing backpropagation through NUFFT operators for training neural networks. This package was inspired in large part by the NUFFT implementation in the Michigan Image Reconstruction Toolbox (Matlab).",
     "keywords": [

--- a/_data/update.rb
+++ b/_data/update.rb
@@ -40,8 +40,15 @@ def get_update_time_from_github(project, github_api, username, password)
     if response["commit"]
         return response["commit"]["commit"]["author"]["date"][0,10]
     else
-        return "nodatefound"
+        # Check if using main branch if no master found
+        url = github_api + repo_uri.path + "/branches/main"
+        response = get_api_response url, username, password
+        if response["commit"]
+            return response["commit"]["commit"]["author"]["date"][0,10]
+        end
     end
+
+    return "nodatefound"
 end
 
 def get_update_time_from_bitbucket(project, bitbucket_api)


### PR DESCRIPTION
Currently dates won't update if a repository uses a branch with a name other than `master`. Since a lot of the open source community is switching to `main`, I made a modification to how the GitHub API works to handle this case if no response is found for `master`.

This PR also includes a fix for my project URL string, but I can split that out to another PR if preferred.