### PR TITLE
Add support for Codeberg in update script

### DIFF
--- a/_data/update.rb
+++ b/_data/update.rb
@@ -8,7 +8,7 @@ def get_api_response(url, username="", password="")
     uri = URI.parse(url)
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true
-    request = Net::HTTP::Get.new(uri.path)
+    request = Net::HTTP::Get.new(uri.request_uri)
     if !username.empty? && !password.empty?
         request.basic_auth(username, password)
     end
@@ -46,18 +46,10 @@ end
 
 def get_update_time_from_github(project, github_api, username, password)
     repo_uri = URI.parse(project["repoURL"])
-    url = github_api + repo_uri.path + "/branches/master"
+    url = github_api + repo_uri.path + "/commits?per_page=1"
     response = get_api_response url, username, password
-    if response["commit"]
-        return response["commit"]["commit"]["author"]["date"][0,10]
-    else
-        # Check if using main branch if no master found
-        url = github_api + repo_uri.path + "/branches/main"
-        response = get_api_response url, username, password
-        if response["commit"]
-            return response["commit"]["commit"]["author"]["date"][0,10]
-        end
-    end
+    timestamp = response.dig(0, "commit", "author", "date") if response.is_a?(Array)
+    return timestamp[0,10] unless timestamp.nil?
 
     return "nodatefound"
 end

--- a/_data/update.rb
+++ b/_data/update.rb
@@ -71,14 +71,9 @@ end
 
 def get_update_time_from_codeberg(project, codeberg_api)
     repo_uri = URI.parse(project["repoURL"])
-    repo_url = codeberg_api + "/repos" + repo_uri.path
-    repo = get_api_response repo_url
-    default_branch = repo["default_branch"]
-    return "nodatefound" if default_branch.nil? || default_branch.empty?
-
-    branch_url = repo_url + "/branches/" + URI.encode_www_form_component(default_branch)
-    branch = get_api_response branch_url
-    timestamp = branch.dig("commit", "timestamp")
+    url = codeberg_api + "/repos" + repo_uri.path + "/commits?limit=1"
+    response = get_api_response url
+    timestamp = response.dig(0, "commit", "author", "date") if response.is_a?(Array)
     return timestamp[0,10] unless timestamp.nil?
 
     return "nodatefound"

--- a/_data/update.rb
+++ b/_data/update.rb
@@ -69,6 +69,21 @@ def get_update_time_from_bitbucket(project, bitbucket_api)
     return response["updated_on"][0,10]
 end
 
+def get_update_time_from_codeberg(project, codeberg_api)
+    repo_uri = URI.parse(project["repoURL"])
+    repo_url = codeberg_api + "/repos" + repo_uri.path
+    repo = get_api_response repo_url
+    default_branch = repo["default_branch"]
+    return "nodatefound" if default_branch.nil? || default_branch.empty?
+
+    branch_url = repo_url + "/branches/" + URI.encode_www_form_component(default_branch)
+    branch = get_api_response branch_url
+    timestamp = branch.dig("commit", "timestamp")
+    return timestamp[0,10] unless timestamp.nil?
+
+    return "nodatefound"
+end
+
 #################
 # Get github username/password from input arguments
 
@@ -105,6 +120,7 @@ category_count = {
 citation_api = "https://api.openalex.org/works"
 github_api = "https://api.github.com/repos"
 bitbucket_api = "https://api.bitbucket.org/2.0/repositories"
+codeberg_api = "https://codeberg.org/api/v1"
 
 # Main loop 
 projects.each do |project|
@@ -125,8 +141,15 @@ projects.each do |project|
         end
     elsif repo_uri.host.include? "bitbucket"
         project["dateSoftwareLastUpdated"] = get_update_time_from_bitbucket project, bitbucket_api
+    elsif repo_uri.host == "codeberg.org"
+        newDate = get_update_time_from_codeberg project, codeberg_api
+        if newDate != "nodatefound"
+            project["dateSoftwareLastUpdated"] = newDate
+        else
+            puts "Problem extracting update date for this repo - keeping previous entry"
+        end
     else
-        puts "Repo is neither Github nor Bitbucket"
+        puts "Repo is neither GitHub, Bitbucket, nor Codeberg"
     end
 
     category = project["category"]


### PR DESCRIPTION
The updater script should now be able to get the latest commit time for codeberg repositories.

Turns out it's a simpler query, and a similar query works for github repositories too, so the github function was updated/simplified as well. This should use fewer API tokens for github, as we're getting close to the 60-token limit.

I ran the updater locally and it seems to work. Real test is always on the friday.