### PR TITLE
Update old repo urls

### DIFF
--- a/_data/projects.json
+++ b/_data/projects.json
@@ -208,8 +208,8 @@
     "category": "Simulation",
     "shortDescription": "Koma is an open‐source, high‐performance, easy‐to‐use, extensible, cross‐platform, and general MRI simulation framework.",
     "imageFile": "KomaMRI.png",
-    "mainURL": "https://github.com/cncastillo/KomaMRI.jl/",
-    "repoURL": "https://github.com/cncastillo/KomaMRI.jl/",
+    "mainURL": "https://github.com/JuliaHealth/KomaMRI.jl",
+    "repoURL": "https://github.com/JuliaHealth/KomaMRI.jl",
     "principalDevelopers": "Carlos Castillo-Passi",
     "longDescription": "Koma is a Pulseq-compatible framework to efficiently simulate Magnetic Resonance Imaging (MRI) acquisitions. The main focus of this package is to simulate general scenarios that could arise in pulse sequence development.",
     "keywords": [
@@ -831,8 +831,8 @@
     "category": "Image processing",
     "shortDescription": "Fast quantitative water T2 mapping for muscle MRI",
     "imageFile": "myoqmri.png",
-    "mainURL": "https://github.com/fsantini/MyoQMRI",
-    "repoURL": "https://github.com/fsantini/MyoQMRI",
+    "mainURL": "https://github.com/BAMMri/MyoQMRI",
+    "repoURL": "https://github.com/BAMMri/MyoQMRI",
     "principalDevelopers": "Francesco Santini, Matthias Weigel",
     "longDescription": "This project is an open-source effort to put together tools for quantitative MRI of the muscles. It is written in Python and thus portable and multiplatform.\nCurrently, it supports GPU (cuda)-accelerated water T2 mapping from multi echo spin echo images.\nThe fitting procedure is primarily based on extended phase graph simulation of the multi echo spin echo signal. Slice profile is taken into account.\nFor improved accuracy, a fat fraction map can be given as an input to constrain the fitting.\nB1 and Fat Fraction maps are generated as a byproduct of the fitting.",
     "keywords": [
@@ -860,8 +860,8 @@
     "category": "Multipurpose",
     "shortDescription": "A new quality assessment and evaluation tool for MRI data",
     "imageFile": "MRQy.png",
-    "mainURL": "https://github.com/ccipd/MRQy",
-    "repoURL": "https://github.com/ccipd/MRQy",
+    "mainURL": "https://github.com/viswanath-lab/RadQy",
+    "repoURL": "https://github.com/viswanath-lab/RadQy",
     "principalDevelopers": "Amir Reza Sadri, Satish E. Viswanath",
     "longDescription": "MRQy is a new open-source quality control and assurance tool for MR imaging data, which can be used as a pre-analytical step when developing computational pipelines including radiomics, image analysis, and machine learning. MRQy leverages a Python-JavaScript framework and has been specialized for analyzing large-scale MRI cohorts through the following modules: (i) automatic foreground detection for any MR image from anybody region, from which it will (ii) extract a series of imaging-specific metadata and quality measures generalized to work with any structural MR sequence, in order to (iii) compute representations that capture relevant MR image quality trends in a data cohort. These are presented within a specialized HTML5-based front-end which can be easily interrogated by the end-user to identify batch effects and imaging artifacts towards curation of MR imaging cohorts of acceptable quality for model development.",
     "keywords": [
@@ -885,7 +885,7 @@
     "extraResources": [
       {
         "resourceType": "Github wiki homepage (4 pages)",
-        "URL": "https://github.com/ccipd/MRQy/wiki"
+        "URL": "https://github.com/viswanath-lab/RadQy/wiki"
       }
     ],
     "dateAddedToMRHub": "2020-08-14",
@@ -1777,9 +1777,9 @@
     "category": "Image processing",
     "shortDescription": "Software package to analyze multi-parametric MRI of the spinal cord, available for Linux, OSX and Windows.",
     "imageFile": "spinal_cord_toolbox.png",
-    "mainURL": "https://github.com/neuropoly/spinalcordtoolbox",
-    "repoURL": "https://github.com/neuropoly/spinalcordtoolbox",
-    "principalDevelopers": "<a href=\"https://github.com/neuropoly/spinalcordtoolbox/graphs/contributors\"><em>Please see here for full list</em></a>",
+    "mainURL": "https://github.com/spinalcordtoolbox/spinalcordtoolbox",
+    "repoURL": "https://github.com/spinalcordtoolbox/spinalcordtoolbox",
+    "principalDevelopers": "<a href=\"https://github.com/spinalcordtoolbox/spinalcordtoolbox/graphs/contributors\"><em>Please see here for full list</em></a>",
     "longDescription": "SCT is a comprehensive and open-source library of analysis tools for multi-parametric MRI of the spinal cord, written in Python and available for Linux, OSX and Windows. It includes templates and atlases of the spinal cord along with state-of-the-art methods for automatic segmentation, registration and metric atlas-based analysis.",
     "keywords": [
       "GitHub",


### PR DESCRIPTION
While testing the updater script, I noticed that the same repositories kept failing to update. What they all have in common is that their repository URL has moved. Web browsers will redirect the old url to the new url, but the API gives an error on the old url.

This change updates the repository URL to their new/current destination, so they shouldn't give any more errors.